### PR TITLE
[Gutil] Remove & symbol. This symbol has been deprecated and marked for inlining. The function being deprecated is absl::MutexLock::MutexLock.

### DIFF
--- a/gutil/BUILD.bazel
+++ b/gutil/BUILD.bazel
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 load("@com_google_googleapis_imports//:imports.bzl", "cc_proto_library")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(
     default_visibility = ["//visibility:public"],

--- a/gutil/embed_data/BUILD.bazel
+++ b/gutil/embed_data/BUILD.bazel
@@ -14,6 +14,8 @@
 
 # Generates source files with embedded file contents.
 
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/gutil/embed_data/build_defs.bzl
+++ b/gutil/embed_data/build_defs.bzl
@@ -14,6 +14,8 @@
 
 """Embeds data files into a C++ or Go module."""
 
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 def clean_dep(dep):
     """Returns an absolute Bazel path to 'dep'.
 
@@ -89,7 +91,7 @@ def cc_embed_data(
         cmd = "%s $(SRCS) %s" % (generator_location, flags),
         testonly = testonly,
     )
-    native.cc_library(
+    cc_library(
         name = name,
         hdrs = [h_file_output],
         srcs = [cc_file_output],

--- a/gutil/test_artifact_writer.cc
+++ b/gutil/test_artifact_writer.cc
@@ -146,13 +146,13 @@ absl::Status TestArtifactWriter::AppendToTestArtifact(
 
 absl::Status BazelTestArtifactWriter::StoreTestArtifact(
     absl::string_view filename, absl::string_view contents) {
-  absl::MutexLock lock(&this->write_mutex_);
+  absl::MutexLock lock(this->write_mutex_);
   return WriteToTestArtifact(filename, contents, std::ios_base::trunc,
                              open_file_by_filepath_);
 }
 absl::Status BazelTestArtifactWriter::AppendToTestArtifact(
     absl::string_view filename, absl::string_view contents) {
-  absl::MutexLock lock(&this->write_mutex_);
+  absl::MutexLock lock(this->write_mutex_);
   return WriteToTestArtifact(filename, contents, std::ios_base::app,
                              open_file_by_filepath_);
 }

--- a/gutil_deps.bzl
+++ b/gutil_deps.bzl
@@ -61,3 +61,10 @@ def gutil_deps():
             strip_prefix = "googleapis-f405c718d60484124808adb7fb5963974d654bb4",
             sha256 = "406b64643eede84ce3e0821a1d01f66eaf6254e79cb9c4f53be9054551935e79",
         )
+    if not native.existing_rule("rules_cc"):
+        http_archive(
+            name = "rules_cc",
+            sha256 = "b8b918a85f9144c01f6cfe0f45e4f2838c7413961a8ff23bc0c6cdf8bb07a3b6",
+            strip_prefix = "rules_cc-0.1.5",
+            url = "https://github.com/bazelbuild/rules_cc/releases/download/0.1.5/rules_cc-0.1.5.tar.gz",
+        )


### PR DESCRIPTION
[Gutil] Remove & symbol. This symbol has been deprecated and marked for inlining. The function being deprecated is absl::MutexLock::MutexLock.
