### PR TITLE
Fix RETURN_IF_ERROR variable shadowing UB

### DIFF
--- a/gutil/status.h
+++ b/gutil/status.h
@@ -279,9 +279,13 @@ class StatusBuilderHolder {
 //     RETURN_IF_ERROR(Foo()).LogError() << "Additional Info";
 //     return absl::OkStatus()
 //   }
-#define RETURN_IF_ERROR(expr)                     \
-  for (absl::Status status = expr; !status.ok();) \
-  return gutil::StatusBuilder(std::move(status))
+// Use a unique variable name to avoid shadowing user variables named `status`.
+#define __RETURN_IF_ERROR_VAL_DIRECT(arg) __RETURN_IF_ERROR_STATUS_##arg
+#define __RETURN_IF_ERROR_VAL(arg) __RETURN_IF_ERROR_VAL_DIRECT(arg)
+#define RETURN_IF_ERROR(expr)                                                \
+  for (absl::Status __RETURN_IF_ERROR_VAL(__LINE__) = expr;                  \
+       !__RETURN_IF_ERROR_VAL(__LINE__).ok();)                               \
+  return gutil::StatusBuilder(std::move(__RETURN_IF_ERROR_VAL(__LINE__)))
 
 // These macros help create unique variable names for ASSIGN_OR_RETURN. Not for
 // public use.


### PR DESCRIPTION
## Bug

`RETURN_IF_ERROR(status)` expands to `for (absl::Status status = status; ...)`,
which is self-initialization from an uninitialized variable when the user's
expression is named `status`. Undefined behavior — observed as `bad_alloc`
crashes in production.

## Fix

Use `__LINE__`-based unique variable names, matching `ASSIGN_OR_RETURN`.

## Found in

sonic-pins `ReadPiEntitiesSorted` — the sort comparator had a local
`absl::Status status` followed by `RETURN_IF_ERROR(status)`. Caused
crashes in the DVaaS E2E test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)